### PR TITLE
Add invoke module support to TemplateModifierBase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 
 setuptools.setup(
     name="mwcleric",


### PR DESCRIPTION
Resolve #23

These changes would allow code such as:
```py
TemplateModifier(site,
    [
        'Module:Foo',
        'Bar', # Template:Bar
    ],
    summary='bot edit').run()
```
However, if module logic would be better in a separate class, let me know.