### PR TITLE
Use calendar.timegm() instead of time.mktime()

### DIFF
--- a/mwcleric/wiki_client.py
+++ b/mwcleric/wiki_client.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import time
+import calendar
 from typing import Optional, Union, List, Dict, Generator
 
 from mwclient.errors import APIError, MaximumRetriesExceeded
@@ -468,4 +469,4 @@ class WikiClient(object):
         if page.last_rev_time is None:
             # force last_rev_time to populate
             _text = page.text()
-        return datetime.now() - datetime.fromtimestamp(time.mktime(page.last_rev_time))
+        return datetime.now() - datetime.fromtimestamp(calendar.timegm(page.last_rev_time))


### PR DESCRIPTION
In last_edited_interval, time.mktime() converts the time assuming the tuple uses local timezone, but page.last_rev_time uses UTC. Use calendar.timegm() to convert the time correctly