### PR TITLE
Add upload method, pass max_retries_mwc to mwclient when relogging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 setuptools.setup(
     name="mwcleric",


### PR DESCRIPTION
I'm adding a wrapper for mwclients upload method so it retries when the upload fails

Also when we get a new client when retrying we should pass `self.max_retries_mwc` as we do when we initialize the class, otherwise we are passing mwclerics max_retries parameter and then for each time mwcleric retries mwclient retries another 10 times and I think thats not intended