### PR TITLE
Make site_user and site_pw default to an empty string if not present in user file

### DIFF
--- a/mwcleric/auth_credentials.py
+++ b/mwcleric/auth_credentials.py
@@ -65,8 +65,8 @@ class AuthCredentials(object):
                 raise InvalidUserFile
             self.password = user_info['password']
             self.username = user_info['username']
-            self.site_pw = user_info['site_pw']
-            self.site_user = user_info['site_user']
+            self.site_pw = user_info.get('site_pw', '')
+            self.site_user = user_info.get('site_user', '')
 
     def get_user_data_from_file(self, user_file, base_path):
         account_file = os.path.join(base_path, self.file_pattern.format(user_file.lower()))


### PR DESCRIPTION
After updating mwcleric from an older version (0.8.7 in my case), `AuthCredentials` tries to get `site_user` and `site_pw` from the user credentials file and fails because the keys aren't present.

When the library prompts the user and creates a new file it uses an empty string for `site_user` and `site_pw` if these weren't provided, so I used that as the default value.