### PR TITLE
Use page_list only if title_list is None

### DIFF
--- a/mwcleric/template_modifier.py
+++ b/mwcleric/template_modifier.py
@@ -38,7 +38,7 @@ class TemplateModifierBase(PageModifierBase):
         self.recursive = recursive
         self.check_deletion_marks = False
         self.invoke_namespace = None
-        if not title_list:
+        if title_list is None:
             page_list = page_list if page_list else site.pages_using(template, namespace=namespace)
         super().__init__(site, page_list=page_list, title_list=title_list, limit=limit, summary=summary,
                          quiet=quiet, lag=lag, tags=tags, skip_pages=skip_pages,


### PR DESCRIPTION
I think we should fall back to `page_list` only when `title_list` is `None`. If `title_list` is an empty list we will end up modifying all pages using a template instead of doing nothing. This wasn't an issue before because `PageModifierBase` used to override `page_list` in these cases.
https://github.com/RheingoldRiver/mwcleric/blob/9fd7de994ad24e1b8d9b927d84924726ed957f43/mwcleric/page_modifier.py#L48-L49