### PR TITLE
Remove save_tile method from wiki_client.py

### DIFF
--- a/mwcleric/wiki_client.py
+++ b/mwcleric/wiki_client.py
@@ -441,10 +441,6 @@ class WikiClient(object):
         if not was_successful:
             raise RetriedLoginAndStillFailed(failure_type, codes)
 
-    def save_tile(self, title: str, text, summary=None, minor=False, bot=True, section=None, **kwargs):
-        self.save(self.client.pages[title], text,
-                  summary=summary, minor=minor, bot=bot, section=section, **kwargs)
-
     def save_title(self, title: str, text, summary=None, minor=False, bot=True, section=None, **kwargs):
         self.save(self.client.pages[title], text,
                   summary=summary, minor=minor, bot=bot, section=section, **kwargs)


### PR DESCRIPTION
Removed misnamed `save_tile` method from wiki_client.py.

Just below is a `save_title` function with the same parameters and function body. I believe this function is a typo?